### PR TITLE
nits: Replace slice trick with String.prototype.padStart

### DIFF
--- a/docs/pomodoro.html
+++ b/docs/pomodoro.html
@@ -30,7 +30,7 @@
     <div id="timer"></div>
     <script type="text/javascript">
       function zeroPadding(number, length) {
-        return (Array(length).join("0") + number).slice(-length);
+        return number.toString().padStart(length, "0");
       }
 
       function calculateClassName(parameters) {


### PR DESCRIPTION
There is a built-in function [`String.prototype.padStart`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padStart), which pads a string to the given length.

(Added in ES2017: [ECMAScript 2017 (ES8): the final feature set](https://2ality.com/2016/02/ecmascript-2017.html#:~:text=string%20padding%20(jordan%20harband%2C%20rick%20waldron)))