### PR TITLE
Add displayState option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ For example:
   - 25 min work + 5 min break
 - https://r7kamura.github.io/obs-browser-sources/pomodoro.html?work=20&break=10
   - 20 min work + 10 min break
+- https://r7kamura.github.io/obs-browser-sources/pomodoro.html?displayState=1
+  - with the name of state (work/break) displayed
 
 ### Auto scene switcher
 

--- a/docs/pomodoro.html
+++ b/docs/pomodoro.html
@@ -27,6 +27,7 @@
     </style>
   </head>
   <body>
+    <div id="state"></div>
     <div id="timer"></div>
     <script type="text/javascript">
       function zeroPadding(number, length) {
@@ -85,13 +86,23 @@
         }
       }
 
+      function displayState(parameters) {
+        if (parameters.displayState) {
+            document.getElementById("state").textContent = document.getElementById("timer").className;
+            document.body.style.fontSize = "16vw";
+            document.body.style.flexDirection = 'column';
+        }
+      }
+
       function getParameters() {
         const params = new URL(window.location.href).searchParams;
         const breakString = params.get("break") || "10";
         const workString = params.get("work") || "50";
+        const displayStateString = params.get("displayState") || "0";
         return {
           break: parseInt(breakString, 10),
           work: parseInt(workString, 10),
+          displayState: parseInt(displayStateString, 10)
         };
       }
 
@@ -101,6 +112,7 @@
         element.textContent = calculateTimerText(parameters);
         element.className = calculateClassName(parameters);
         switchScene(parameters);
+        displayState(parameters);
       }, 1000);
     </script>
   </body>


### PR DESCRIPTION
Display current state (work/break) when the query `displayState=1` is passed.

Working example: <https://pn11.github.io/obs-browser-sources/pomodoro.html?displayState=1>